### PR TITLE
chore(deploy): add cross-platform setup script for cert-manager and Auto-mTLS operator

### DIFF
--- a/deploy/setup-auto-mtls.ps1
+++ b/deploy/setup-auto-mtls.ps1
@@ -1,0 +1,48 @@
+#!/usr/bin/env pwsh
+#Requires -Version 5.1
+$ErrorActionPreference = "Stop"
+
+# ---- Config (overridable via env) ----
+$CERT_MANAGER_VERSION   = $env:CERT_MANAGER_VERSION
+if ([string]::IsNullOrWhiteSpace($CERT_MANAGER_VERSION)) { $CERT_MANAGER_VERSION = "v1.18.2" }
+
+$AUTO_MTLS_MANIFEST_URL = $env:AUTO_MTLS_MANIFEST_URL
+if ([string]::IsNullOrWhiteSpace($AUTO_MTLS_MANIFEST_URL)) { $AUTO_MTLS_MANIFEST_URL = "https://raw.githubusercontent.com/kupher-tools/auto-mtls/refs/heads/main/deploy/auto-mtls-deploy.yaml" }
+
+function Need($cmd) {
+  if (-not (Get-Command $cmd -ErrorAction SilentlyContinue)) {
+    Write-Error "Missing dependency: '$cmd' not found on PATH"
+  }
+}
+
+Write-Host "[*] Preflight checks"
+Need "kubectl"
+Need "helm"
+
+Write-Host "[*] Install/upgrade cert-manager ($CERT_MANAGER_VERSION)"
+helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager `
+  --version $CERT_MANAGER_VERSION `
+  --namespace cert-manager `
+  --create-namespace `
+  --set crds.enabled=true | Out-Host
+
+Write-Host "[*] Waiting for cert-manager components..."
+kubectl -n cert-manager rollout status deploy/cert-manager --timeout=180s | Out-Host
+kubectl -n cert-manager rollout status deploy/cert-manager-webhook --timeout=180s | Out-Host
+kubectl -n cert-manager rollout status deploy/cert-manager-cainjector --timeout=180s | Out-Host
+Write-Host "[+] cert-manager ready"
+
+Write-Host "[*] Deploy Auto-mTLS Operator"
+kubectl apply -f $AUTO_MTLS_MANIFEST_URL | Out-Host
+
+Write-Host "[*] Waiting for auto-mtls operator..."
+kubectl -n auto-mtls rollout status deploy/auto-mtls-operator --timeout=180s | Out-Host
+Write-Host "[✓] Auto-mTLS Operator ready"
+
+
+
+# .\deploy\setup-auto-mtls.ps1
+# or with overrides:
+# $env:CERT_MANAGER_VERSION = "v1.18.2"
+# $env:AUTO_MTLS_MANIFEST_URL = "https://raw.githubusercontent.com/kupher-tools/auto-mtls/refs/heads/main/deploy/auto-mtls-deploy.yaml"
+# .\deploy\setup-auto-mtls.ps1

--- a/deploy/setup-auto-mtls.sh
+++ b/deploy/setup-auto-mtls.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env sh
+set -eu
+
+# ---- Config (overridable) ----
+: "${CERT_MANAGER_VERSION:=v1.18.2}"
+: "${AUTO_MTLS_MANIFEST_URL:=https://raw.githubusercontent.com/kupher-tools/auto-mtls/refs/heads/main/deploy/auto-mtls-deploy.yaml}"
+
+need() { command -v "$1" >/dev/null 2>&1 || { echo "ERROR: missing '$1' on PATH"; exit 1; }; }
+
+echo "[*] Preflight checks"
+need kubectl
+need helm
+
+echo "[*] Install/upgrade cert-manager ($CERT_MANAGER_VERSION)"
+helm upgrade --install cert-manager oci://quay.io/jetstack/charts/cert-manager \
+  --version "$CERT_MANAGER_VERSION" \
+  --namespace cert-manager \
+  --create-namespace \
+  --set crds.enabled=true
+
+echo "[*] Waiting for cert-manager components..."
+kubectl -n cert-manager rollout status deploy/cert-manager --timeout=180s
+kubectl -n cert-manager rollout status deploy/cert-manager-webhook --timeout=180s
+kubectl -n cert-manager rollout status deploy/cert-manager-cainjector --timeout=180s
+echo "[+] cert-manager ready"
+
+echo "[*] Deploy Auto-mTLS Operator"
+kubectl apply -f "$AUTO_MTLS_MANIFEST_URL"
+
+echo "[*] Waiting for auto-mtls operator..."
+kubectl -n auto-mtls rollout status deploy/auto-mtls-operator --timeout=180s
+echo "[✓] Auto-mTLS Operator ready"
+
+# Execution
+
+# chmod +x deploy/setup-auto-mtls.sh
+# deploy/setup-auto-mtls.sh
+# or with overrides:
+# CERT_MANAGER_VERSION=v1.18.2 \
+# AUTO_MTLS_MANIFEST_URL="https://raw.githubusercontent.com/kupher-tools/auto-mtls/refs/heads/main/deploy/auto-mtls-deploy.yaml" \
+# deploy/setup-auto-mtls.sh


### PR DESCRIPTION
This PR adds a single-step installer for both cert-manager and the Auto-mTLS Operator:

- `deploy/setup-auto-mtls.sh` (POSIX: Linux/macOS/WSL)
- `deploy/setup-auto-mtls.ps1` (Windows PowerShell)

Key points:
- Idempotent, CI-friendly; fails fast on errors
- Preflight checks for kubectl/helm
- Installs cert-manager (CRDs enabled), waits for controller/webhook/cainjector
- Applies Auto-mTLS Operator manifest and waits for rollout in the correct namespace (`auto-mtls-system`)
- Versions/URLs overridable via env vars (`CERT_MANAGER_VERSION`, `AUTO_MTLS_MANIFEST_URL`)

Tested locally on kind v1.33.1: cert-manager and operator roll out successfully.

This **addresses #2** by providing a reusable step the CI workflow can call (the actual GitHub Actions workflow can invoke `deploy/setup-auto-mtls.sh`).
Happy to tweak naming/paths or split into per-tool scripts if preferred.
